### PR TITLE
Allowing more control over the life-time of material shader programs

### DIFF
--- a/extension/src/starling/display/Graphics.as
+++ b/extension/src/starling/display/Graphics.as
@@ -10,6 +10,7 @@ package starling.display
 	import starling.display.graphics.RoundedRectangle;
 	import starling.display.graphics.Stroke;
 	import starling.display.materials.IMaterial;
+	import starling.display.materials.Program3DCache;
 	import starling.display.shaders.fragment.TextureFragmentShader;
 	import starling.display.util.CurveUtil;
 	import starling.textures.Texture;
@@ -522,6 +523,17 @@ package starling.display
 				}
 				_currentStroke = null;
 			}
+		}
+		
+		// Specify either:
+		// 1) Off: Explicit flushing of non-referenced programs using flushNonReferencedPrograms()
+		// 2) On: Programs are flushed when there reference count reaches zero
+		public static function set autoDelete(on:Boolean):void {Program3DCache.autoDelete = on;}
+		public static function get autoDelete():Boolean {return Program3DCache.autoDelete;}
+		
+		public static function flushNonReferencedPrograms():void
+		{
+			Program3DCache.flushNonReferencedPrograms();
 		}
 	}
 }

--- a/extension/src/starling/display/materials/Program3DCache.as
+++ b/extension/src/starling/display/materials/Program3DCache.as
@@ -4,17 +4,25 @@ package starling.display.materials
 	import flash.display3D.Program3D;
 	import flash.utils.Dictionary;
 	
+	import starling.display.Graphics;
 	import starling.display.shaders.IShader;
 
-	internal class Program3DCache
+	public class Program3DCache
 	{
 		private static var uid							:int = 0;
 		private static var uidByShaderTable				:Dictionary = new Dictionary(true);
 		private static var programByUIDTable			:Object = {};
 		private static var uidByProgramTable			:Dictionary = new Dictionary(false);
 		private static var numReferencesByProgramTable	:Dictionary = new Dictionary();
+		private static var _autoDelete					:Boolean = true;
 		
-		public static function getProgram3D( context:Context3D, vertexShader:IShader, fragmentShader:IShader ):Program3D
+		// Specify either:
+		// 1) Off: Explicit flushing of non-referenced programs using flushNonReferencedPrograms()
+		// 2) On: Programs are flushed when there reference count reaches zero
+		public static function set autoDelete(on:Boolean):void {_autoDelete = on;}
+		public static function get autoDelete():Boolean {return _autoDelete;}
+		
+		internal static function getProgram3D( context:Context3D, vertexShader:IShader, fragmentShader:IShader ):Program3D
 		{
 			var vertexShaderUID:int = uidByShaderTable[vertexShader];
 			if ( vertexShaderUID == 0 )
@@ -44,28 +52,63 @@ package starling.display.materials
 			return program3D;
 		}
 		
-		public static function releaseProgram3D( program3D:Program3D ):void
+		internal static function releaseProgram3D( program3D:Program3D ):void
 		{
-			if ( numReferencesByProgramTable[program3D] == null )
+			if (numReferencesByProgramTable[program3D] == null)
 			{
 				throw( new Error( "Program3D is not in cache" ) );
 				return;
 			}
 			
 			var numReferences:int = numReferencesByProgramTable[program3D];
+			if (!_autoDelete && numReferences == 0)
+			{
+				throw( new Error( "Reference count below zero" ) );
+				return;
+			}
 			numReferences--;
 			
-			if ( numReferences == 0 )
+			if ( numReferences == 0 && _autoDelete )
 			{
-				program3D.dispose();
-				delete numReferencesByProgramTable[program3D];
-				var program3DUID:String = uidByProgramTable[program3D];
-				delete programByUIDTable[program3DUID];
-				delete uidByProgramTable[program3D];
-				return;
+				deleteInCache(program3D);
 			}
 			
 			numReferencesByProgramTable[program3D] = numReferences;
 		}
+		
+		
+		// Abstracted internal function for deleting a program from the cache
+		// Either invoked automatically when reference count reaches zero or
+		// through flushNonReferencedPrograms().
+		private static function deleteInCache(program3D:Program3D):void {
+			program3D.dispose();
+			delete numReferencesByProgramTable[program3D];
+			var program3DUID:String = uidByProgramTable[program3D];
+			delete programByUIDTable[program3DUID];
+			delete uidByProgramTable[program3D];
+			return;
+		}
+		
+		// If setAutoDelete(false), use this function to flush non-referenced programs
+		// at any point during the game loop.  Useful in situations where all objects
+		// using a particular program are redrawn every frame.
+		public static function flushNonReferencedPrograms():void
+		{
+			var programsToDelete:Array = new Array();
+			for (var program3D:Program3D in numReferencesByProgramTable) 
+			{
+				if (numReferencesByProgramTable[program3D] == 0)
+				{
+					programsToDelete.push(program3D);
+				}
+			}
+			
+			for each (program3D in programsToDelete) 
+			{
+				deleteInCache(program3D);
+			}
+			
+		}
+		
 	}
 }


### PR DESCRIPTION
*\* SORRY FOR THE DOUBLE UP! - First request I've made, didn't think to branch first...

First of all: Thanks so much for this extensions.  Saved me a huge amount of time for rendering basic primitives - something that's pretty well needed in most games, if only for debugging.  Came across a few hurdles in my particular use case that I think might be of benefit for other people.  I originally forked from the wrong person - hopefully that doesn't cause any problems (I've adjusted my upstream accordingly).

Problem:

In situations where SEG is used for only dynamically drawn content, it's possible that all primitives will be destroyed and remade for a particular vertex/fragment shader combo.  In such a situation the graphics are cleared each frame - where reference counts will drop to zero for the shader program which will automatically destroy it.  At render phase, the missing shader will be re-instantiated.  This means the shader program will be remade every frame causing poor performance.

Solution:

Provide a flag that defaults for the usual auto-extinction of shader programs but allows this automatic feature to be disabled.  An explicit function is provided which can be executed during the most appropriate time in the game loop according to individual project needs.  It iterates through all programs and selects any zero-referenced programs for destruction in one batch.
