### PR TITLE
Using degenerates to reduce extra vertex buffers cause by moveTo(...)

### DIFF
--- a/extension/src/starling/display/Graphics.as
+++ b/extension/src/starling/display/Graphics.as
@@ -360,26 +360,11 @@ package starling.display
 		
 		public function moveTo(x:Number, y:Number):void
 		{
-			if ( _currentStroke && _strokeThickness > 0 )
-			{
-				_currentStroke.addBreak();
-			}
-			
-			if (_currentFill) 
-			{
-				_currentFill.addVertex( x, y );
-			}
-			
-			_currentX = x;
-			_currentY = y;
-		}
-		
-		// Degenerates allow for better performance as they do not terminate
-		// the vertex buffer but instead use zero size polygons to translate
-		// from the end point of the last sections of the stroke to the
-		// start of the new point.
-		public function moveToWithDegenerates(x:Number, y:Number):void
-		{
+			// Move to changed to add degenerates:
+			// Degenerates allow for better performance as they do not terminate
+			// the vertex buffer but instead use zero size polygons to translate
+			// from the end point of the last section of the stroke to the
+			// start of the new point.
 			if ( _currentStroke && _strokeThickness > 0 )
 			{
 				_currentStroke.addDegenerates(x, y);
@@ -387,9 +372,7 @@ package starling.display
 			
 			if (_currentFill) 
 			{
-				_currentFill.addVertex( _currentX, _currentY );
-				_currentFill.addVertex( x, y );
-				_currentFill.addVertex( x, y );
+				_currentFill.addDegenerates( x, y );
 			}
 			
 			_currentX = x;

--- a/extension/src/starling/display/graphics/Fill.as
+++ b/extension/src/starling/display/graphics/Fill.as
@@ -46,6 +46,24 @@ package starling.display.graphics
 			super.dispose();
 		}
 		
+		public function addDegenerates( destX:Number, destY:Number, color:uint = 0xFFFFFF, alpha:Number = 1  ):void
+		{
+			if (_numVertices < 1)
+			{
+				return;
+			}
+			var lastVertex:Vector.<Number> = fillVertices.prev.vertex;
+			var lastColor:uint;
+			lastColor = uint( lastVertex[3] * 255 ) << 16; // R
+			lastColor |= uint( lastVertex[4] * 255 ) << 8; // G
+			lastColor |= uint( lastVertex[5] * 255 ); // B
+			var r:Number = ( color >> 16 ) / 255;
+			var g:Number = (( color & 0x00FF00 ) >> 8) / 255;
+			var b:Number = ( color & 0x0000FF ) / 255;
+			addVertex(lastVertex[0], lastVertex[1], lastColor, lastVertex[6]);
+			addVertex(destX, destY, color, alpha);
+		}
+		
 		public function addVertex( x:Number, y:Number, color:uint = 0xFFFFFF, alpha:Number = 1 ):void
 		{
 			var r:Number = (color >> 16) / 255;


### PR DESCRIPTION
Problem:

For the project I'm working on I needed to draw dotted lines and to update them every frame.  Using moveTo(..) and lineTo(..) in succession would provide the desired look but would slow the game right down.  Upon inspection, I realised that moveTo causes the vertex batch to be terminated and a new one created.

Solution:

Created a new function called moveToWithDegenerates(..).  It provides alternative functionality that uses zero-sized polygons to translate from point to point in the graphic without having to start a new vertex batch.  This provided highly significant speed gains in situations where lines are segmented.
