### PR TITLE
Objects using Graphics are testable

### DIFF
--- a/extension/src/starling/display/graphics/Graphic.as
+++ b/extension/src/starling/display/graphics/Graphic.as
@@ -80,8 +80,11 @@ package starling.display.graphics
 			
 			minBounds = new Point();
 			maxBounds = new Point();
-			
-			Starling.current.addEventListener(Event.CONTEXT3D_CREATE, onContextCreated);
+
+			if (Starling.current)
+			{
+				Starling.current.addEventListener(Event.CONTEXT3D_CREATE, onContextCreated);
+			}
 		}
 		
 		private function onContextCreated( event:Event ):void


### PR DESCRIPTION
added a check if Starling.current is not null before accessing it in Graphics constructor. It's needed only for testing purposes. When writing integration tests for some objects that use Graphic object it always throws an exception because Staring instance is not defined due to the fact that it's mocked. So this check allows to prevent that exception and write tests.
