### PR TITLE
Added clear() function to TriangleStrip.as

### DIFF
--- a/extension/src/starling/display/graphics/TriangleStrip.as
+++ b/extension/src/starling/display/graphics/TriangleStrip.as
@@ -34,6 +34,13 @@ package starling.display.graphics
 			setGeometryInvalid();
 		}
 		
+		public function clear():void
+		{
+			vertices.length = 0;
+			indices.length = 0;
+			numVertices =  0;
+		}
+		
 		override protected function shapeHitTestLocalInternal( localX:Number, localY:Number ):Boolean
 		{
 			var numIndices:int = indices.length;


### PR DESCRIPTION
Possibly add to Graphic.as instead?

Either way, before I wrote this little function in I had to dispose and initialise a new TriangleStrip instance every frame - bad for performance!
