### PR TITLE
more test-ready

### DIFF
--- a/extension/src/starling/display/graphics/Graphic.as
+++ b/extension/src/starling/display/graphics/Graphic.as
@@ -101,9 +101,12 @@ package starling.display.graphics
 		
 		override public function dispose():void
 		{
-			Starling.current.removeEventListener(Event.CONTEXT3D_CREATE, onContextCreated);
-			super.dispose();
-			
+			if (Starling.current)
+			{
+				Starling.current.removeEventListener(Event.CONTEXT3D_CREATE, onContextCreated);
+				super.dispose();
+			}
+
 			if ( vertexBuffer )
 			{
 				vertexBuffer.dispose();


### PR DESCRIPTION
this commit is related to the same issue as for the one from 29. November 2013 15:57:40.

In short, it makes it possible to test classes that use graphics extension.
