### PR TITLE
Bugfix for handleGraphicsDataType()

### DIFF
--- a/extension/src/starling/display/graphicsEx/GraphicsEx.as
+++ b/extension/src/starling/display/graphicsEx/GraphicsEx.as
@@ -71,7 +71,7 @@ package starling.display.graphicsEx
 		protected function handleGraphicsDataType(gfxData:flash.display.IGraphicsData ) : void
 		{
 			if ( gfxData is flash.display.GraphicsPath ) 
-				drawPath(flash.display.GraphicsPath(gfxData).commands, flash.display.GraphicsPath(gfxData).data, flash.display.GraphicsPath(gfxData).winding);
+				drawPath( (gfxData as flash.display.GraphicsPath).commands, (gfxData as flash.display.GraphicsPath).data, (gfxData as flash.display.GraphicsPath).winding);
 			else if ( gfxData is flash.display.GraphicsEndFill )
 				endFill();
 		//	else if ( gfxData is flash.display.GraphicsBitmapFill ) // TODO - With the righteous removal of GraphicsBitmapFill, how do we solve this? /IonSwitz


### PR DESCRIPTION
Bugfix a type coercion error in handleGraphicsDataType() when calling drawGraphicsData() with a Vector.<flash.display.IGraphicsData> :: The crash only happens when packaging the code for iOS in Ad Hoc mode. It throws an Error #1034: Type Coercion failed: cannot convert Vector.<int> to ..
