### PR TITLE
Fix a bug of using material.

### DIFF
--- a/extension/src/starling/display/Graphics.as
+++ b/extension/src/starling/display/Graphics.as
@@ -122,8 +122,8 @@ package starling.display
 			endFill();
 			
 			_fillStyleSet 	= true;
-			_fillColor 		= 0xFFFFFF;
-			_fillAlpha 		= 1;
+			_fillColor 		= material.color;
+			_fillAlpha 		= material.alpha;
 			_fillTexture 	= null;
 			_fillMaterial 	= material;
 			if ( uvMatrix )
@@ -194,8 +194,8 @@ package starling.display
 			
 			_strokeStyleSet			= !isNaN(thickness) && thickness > 0 && material;
 			_strokeThickness		= thickness;
-			_strokeColor			= 0xFFFFFF;
-			_strokeAlpha			= 1;
+			_strokeColor			= material.color;
+			_strokeAlpha			= material.alpha;
 			_strokeTexture			= null;
 			_strokeMaterial			= material;
 		}


### PR DESCRIPTION
Hi, I'm using this extension to develop a game now.

It has no effect even color is set to material when I use TextureMaterial to draw a line. I read the code found that the color of material isn't set to the final color, so I did some changes and finally it works.
