### PR TITLE
fix for NGon-fans and arcs become larger angle on specific angles and numSides.

### DIFF
--- a/extension/src/starling/display/graphics/NGon.as
+++ b/extension/src/starling/display/graphics/NGon.as
@@ -459,7 +459,7 @@ package starling.display.graphics
 				var prevRadians:Number = radians-radiansPerDivision;
 				
 				var t:Number
-				if ( radians < startAngle && nextRadians > startAngle )
+				if ( radians < startAngle )
 				{
 					var nextX:Number = Math.sin(nextRadians) * radius;
 					var nextY:Number = -Math.cos(nextRadians) * radius;
@@ -467,7 +467,7 @@ package starling.display.graphics
 					x += t * (nextX-x);
 					y += t * (nextY-y);
 				}
-				else if ( radians > endAngle && prevRadians < endAngle )
+				else if ( radians > endAngle )
 				{
 					var prevX:Number = Math.sin(prevRadians) * radius;
 					var prevY:Number = -Math.cos(prevRadians) * radius;
@@ -525,7 +525,7 @@ package starling.display.graphics
 				var prevAngle:Number = angle-radiansPerDivision;
 				
 				var t:Number
-				if ( angle < startAngle && nextAngle > startAngle )
+				if ( angle < startAngle )
 				{
 					sin = Math.sin(nextAngle);
 					cos = Math.cos(nextAngle);
@@ -539,7 +539,7 @@ package starling.display.graphics
 					x2 += t * (nextX2-x2);
 					y2 += t * (nextY2-y2);
 				}
-				else if ( angle > endAngle && prevAngle < endAngle )
+				else if ( angle > endAngle )
 				{
 					sin = Math.sin(prevAngle);
 					cos = Math.cos(prevAngle);

--- a/tests/02_NGon_Test/.actionScriptProperties
+++ b/tests/02_NGon_Test/.actionScriptProperties
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<actionScriptProperties analytics="false" mainApplicationPath="Main.as" projectUUID="a02457f9-5ec2-432c-b678-38f6d018f82b" version="11">
+  <compiler additionalCompilerArguments="-locale en_US" advancedTelemetry="false" autoRSLOrdering="true" copyDependentFiles="true" fteInMXComponents="false" generateAccessible="false" htmlExpressInstall="true" htmlGenerate="false" htmlHistoryManagement="true" htmlPlayerVersionCheck="true" includeNetmonSwc="false" outputFolderPath="bin-debug" removeUnusedRSL="true" sourceFolderPath="src" strict="true" targetPlayerVersion="0.0.0" useApolloConfig="false" useDebugRSLSwfs="true" useFlashSDK="true" verifyDigests="true" warn="true">
+    <compilerSourcePath>
+      <compilerSourcePathEntry kind="1" linkType="1" path="${PARENT-3-PROJECT_LOC}/Starling-Framework/starling/src"/>
+      <compilerSourcePathEntry kind="1" linkType="1" path="${PARENT-2-PROJECT_LOC}/extension/src"/>
+    </compilerSourcePath>
+    <libraryPath defaultLinkType="0">
+      <libraryPathEntry kind="4" path="">
+        <excludedEntries>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/automation_charts.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="1" linkType="1" path="${PROJECT_FRAMEWORKS}/locale/{locale}"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/advancedgrids.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/qtp.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/automation_air.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/charts.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/framework.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/mx/mx.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/netmon.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/spark.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/sparkskins.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/rpc.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/datavisualization.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/qtp_air.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/videoPlayer.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/spark_dmv.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/automation.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/automation_dmv.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/flash-integration.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/automation_flashflexkit.swc" useDefaultLinkType="false"/>
+          <libraryPathEntry kind="3" linkType="1" path="${PROJECT_FRAMEWORKS}/libs/automation_agent.swc" useDefaultLinkType="false"/>
+        </excludedEntries>
+      </libraryPathEntry>
+    </libraryPath>
+    <sourceAttachmentPath/>
+  </compiler>
+  <applications>
+    <application path="Main.as"/>
+  </applications>
+  <modules/>
+  <workers/>
+  <buildCSSFiles/>
+  <flashCatalyst validateFlashCatalystCompatibility="false"/>
+</actionScriptProperties>

--- a/tests/02_NGon_Test/.project
+++ b/tests/02_NGon_Test/.project
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>02_NGon_Test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.adobe.flexbuilder.project.flexbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.adobe.flexbuilder.project.actionscriptnature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>[source path] extension-src</name>
+			<type>2</type>
+			<locationURI>PARENT-2-PROJECT_LOC/extension/src</locationURI>
+		</link>
+		<link>
+			<name>[source path] starling-src</name>
+			<type>2</type>
+			<locationURI>PARENT-3-PROJECT_LOC/Starling-Framework/starling/src</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/tests/02_NGon_Test/src/Main.as
+++ b/tests/02_NGon_Test/src/Main.as
@@ -1,0 +1,27 @@
+package  
+{
+	import flash.display.Sprite;
+	import flash.display.StageAlign;
+	import flash.display.StageScaleMode;
+	
+	import starling.core.Starling;
+	
+	[SWF( width="800", height="600", backgroundColor="#ffffff", frameRate="60" )]
+	public class Main extends Sprite 
+	{
+		private var starling	:Starling;
+		
+		public function Main() 
+		{
+			stage.scaleMode = StageScaleMode.NO_SCALE;
+			stage.align = StageAlign.TOP_LEFT;
+			
+			starling = new Starling( NGonTest, stage );
+			
+			starling.antiAliasing = 3;
+			starling.start();
+		}
+		
+	}
+	
+}

--- a/tests/02_NGon_Test/src/NGonTest.as
+++ b/tests/02_NGon_Test/src/NGonTest.as
@@ -1,0 +1,46 @@
+package
+{
+	import starling.display.Shape;
+	import starling.display.Sprite;
+	import starling.display.graphics.NGon;
+	import starling.events.Event;
+	
+	public class NGonTest extends Sprite
+	{	
+		private var shape:Shape;
+		
+		public function NGonTest()
+		{
+			addEventListener(Event.ADDED_TO_STAGE, onAdded);
+		}
+		
+		private function onAdded ( e:Event ):void
+		{
+			addNGon(200, 150, false, 0, 335, 0x00ff00);
+			addNGon(200, 150, false, 0, 336, 0xff0000); // Losing shape when endAngle == 336
+			addNGon(200, 150, false, 0, 337, 0x0000ff);
+			
+			addNGon(600, 150, false, -11, 0, 0x00ff00);
+			addNGon(600, 150, false, -12, 0, 0xff0000); // Losing shape in startAngle == -12
+			addNGon(600, 150, false, -13, 0, 0x0000ff);
+			
+			addNGon(200, 450, true, 0, 335, 0x00ff00);
+			addNGon(200, 450, true, 0, 336, 0xff0000); // Losing shape when endAngle == 336
+			addNGon(200, 450, true, 0, 337, 0x0000ff);
+			
+			addNGon(600, 450, true, -11, 0, 0x00ff00);
+			addNGon(600, 450, true, -12, 0, 0xff0000); // Losing shape in startAngle == -12
+			addNGon(600, 450, true, -13, 0, 0x0000ff);
+		}
+		
+		private function addNGon(x:Number, y:Number, isArc:Boolean, startAngle:Number, endAngle:Number, color:uint):void
+		{
+			var shape:NGon = new NGon(120, 60, isArc ? 60 : 0, startAngle, endAngle);
+			shape.color = color;
+			shape.x = x;
+			shape.y = y;
+			shape.alpha = 0.2;
+			addChild(shape);
+		}
+	}
+}


### PR DESCRIPTION
NGon angle become larger than expected when its startAngle or endAngle are almost on vertices of regular polygon.

example: startAngle==-12 or endAngle==-336 on numSides=60.

In test case 02_NGon_Test, It is expected that the three fan shapes (red, green. blue) will be almost overlapped. But the red fan angle become larger with unfixed code. This also occurs in the case of arcs.